### PR TITLE
update node version to 10.12.0 to support RN 57.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM library/ubuntu:16.04
 # set default build arguments
 ARG ANDROID_TOOLS_VERSION=25.2.5
 ENV NPM_CONFIG_LOGLEVEL info
-ARG NODE_VERSION=9.5.0
+ARG NODE_VERSION=10.12.0
 
 
 # set default environment variables


### PR DESCRIPTION
Hey! We're using your fork in our CI build. RN 57.4.0 introduced a change that doesn't work on Node 9.x. We're using our own fork now for this fix, but wanted to throw this your way as well.